### PR TITLE
Fix unit_price format

### DIFF
--- a/app/controllers/api/v1/merchants/date_controller.rb
+++ b/app/controllers/api/v1/merchants/date_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Merchants::DateController < ApplicationController
   # total revenue on date
   def show
-    render json: TotalRevenueSerializer.new(Merchant.total_revenue_on_date(params["date"])[0])
+    render json: TotalRevenueSerializer.new(Merchant.total_revenue_on_date(params["date"]))
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -27,5 +27,6 @@ class Merchant < ApplicationRecord
     .select("SUM(invoice_items.quantity * invoice_items.unit_price) AS total_revenue")
     .merge(Transaction.successful)
     .where("CAST(invoices.created_at AS text) LIKE ?", "%#{input_date}%")
+    .take
   end
 end

--- a/app/serializers/total_revenue_serializer.rb
+++ b/app/serializers/total_revenue_serializer.rb
@@ -2,6 +2,6 @@ class TotalRevenueSerializer
   include FastJsonapi::ObjectSerializer
 
   attribute :total_revenue do |object|
-    '%.2f' % (object.total_revenue)
+    (object.total_revenue / 100.0).to_s
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -188,14 +188,14 @@ describe "Merchants API:" do
     end
 
     it "returns the total revenue for date x across all merchants" do
-      date = "2012-03-27"
+      Item.all.map {|item| (item.unit_price / 100.0).to_s}
 
-      get "/api/v1/merchants/revenue?date=#{date}"
-      
+      get "/api/v1/merchants/revenue?date=2012-03-27"
+
       revenue = JSON.parse(response.body)["data"]
 
       expect(response).to be_successful
-      expect(revenue["attributes"]["total_revenue"]).to eq("128509.00")
+      expect(revenue["attributes"]["total_revenue"]).to eq("1285.09")
     end
 
     context 'edge cases' do


### PR DESCRIPTION
Fix an issue where the spec harness and my specs did not match up. Both specs are now passing for total revenue by date.